### PR TITLE
Fix CPANTS warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,8 @@ copyright_year   = 2014
 
 [PkgVersion]
 
+[PodVersion]
+
 [GithubMeta]
 issues = 1
 
@@ -29,3 +31,8 @@ issues = 1
 type     = markdown
 filename = README.md
 location = root
+
+[MetaProvides::Class]
+
+[MetaProvides::Package]
+

--- a/lib/Message/MongoDB.pm
+++ b/lib/Message/MongoDB.pm
@@ -8,15 +8,6 @@ use MongoDB;
 
 Message::MongoDB - Message-oriented interface to MongoDB
 
-=head1 VERSION
-
-Version 0.1
-
-=cut
-
-our $VERSION = '0.1';
-
-
 =head1 SYNOPSIS
 
     use Message::MongoDB;

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -10,4 +10,5 @@ BEGIN {
     use_ok( 'Message::MongoDB' ) || print "Bail out!\n";
 }
 
-diag( "Testing Message::MongoDB $Message::MongoDB::VERSION, Perl $], $^X" );
+my $version = $Message::MongoDB::VERSION || 'pre-build';
+diag( "Testing Message::MongoDB $version, Perl $], $^X" );


### PR DESCRIPTION
Fixes “consistent version” and “meta yml has provides” warnings at
http://cpants.cpanauthors.org/dist/Message-MongoDB
